### PR TITLE
Added 'extern' keyword to bshuf_h5filter.h.

### DIFF
--- a/src/bshuf_h5filter.h
+++ b/src/bshuf_h5filter.h
@@ -42,7 +42,7 @@
 #define BSHUF_H5_COMPRESS_LZ4 2
 
 
-H5Z_class_t bshuf_H5Filter[1];
+extern H5Z_class_t bshuf_H5Filter[1];
 
 
 /* ---- bshuf_register_h5filter ----


### PR DESCRIPTION
This fixes #12.