### PR TITLE
Change to typing before use for older C compilers -- HJB

### DIFF
--- a/src/bshuf_h5filter.c
+++ b/src/bshuf_h5filter.c
@@ -29,6 +29,7 @@ uint32_t bshuf_read_uint32_BE(void* buf);
 herr_t bshuf_h5_set_local(hid_t dcpl, hid_t type, hid_t space){
 
     herr_t r;
+    size_t ii;
 
     unsigned int elem_size;
 
@@ -44,7 +45,7 @@ herr_t bshuf_h5_set_local(hid_t dcpl, hid_t type, hid_t space){
     if(r<0) return -1;
 
     // First 3 slots reserved. Move any passed options to higher addresses.
-    for (size_t ii=0; ii < nelements && ii + 3 < nelem_max; ii++) {
+    for (ii=0; ii < nelements && ii + 3 < nelem_max; ii++) {
         values[ii + 3] = tmp_values[ii];
     }
 


### PR DESCRIPTION
As part of the changes for use with NeXus, I have made these changes for the agreed clone of this repository so that we can use it with a wider range of compilers.  I am contacting you from my hjbsch account.  I currently have the cone we will actually use under my yayahjb account that will be moved to the nexusformat organization.  As agreed I am sending you our changes for incorporation in the original repository if you would like. -- Herbert J. Bernstein