### PR TITLE
conda recipe to build anaconda package on linux (#26)

### DIFF
--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -1,0 +1,3 @@
+SET CONDA_HOME=%PREFIX%
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,0 +1,2 @@
+export CONDA_HOME=$PREFIX
+$PYTHON setup.py install     # Python command to install the script

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,0 +1,27 @@
+package:
+    name: bitshuffle
+    version: 0.2.1
+source:
+    # git_url: https://github.com/kiyo-masui/bitshuffle.git
+    # git_rev: 0.2.1
+    path: ..
+    patches:
+      - setup.py.patch
+
+requirements:
+    build:
+        - python
+        - setuptools
+        - cython
+        - numpy
+        - h5py
+        - hdf5
+    run:
+        - python
+        - numpy
+        - h5py
+        - cython
+
+about:
+    home: https://github.com/kiyo-masui/bitshuffle/blob/master/setup.py
+    summary: "bitshuffle library."

--- a/conda-recipe/setup.py.patch
+++ b/conda-recipe/setup.py.patch
@@ -1,0 +1,22 @@
+--- setup.py	2016-01-19 16:56:12.954563000 +0100
++++ xxx.py	2016-01-19 16:56:00.817087000 +0100
+@@ -24,7 +24,7 @@
+     VERSION = VERSION + ".dev%d" % VERSION_DEV
+ 
+ 
+-COMPILE_FLAGS = ['-Ofast', '-march=native', '-std=c99', '-fopenmp']
++COMPILE_FLAGS = ['-ffast-math', '-march=native', '-std=c99', '-fopenmp']
+ # Cython breaks strict aliasing rules.
+ COMPILE_FLAGS += ["-fno-strict-aliasing"]
+ #COMPILE_FLAGS = ['-Ofast', '-march=core2', '-std=c99', '-fopenmp']
+@@ -40,8 +40,8 @@
+ 
+ # Copied from h5py.
+ # TODO, figure out what the canonacal way to do this should be.
+-INCLUDE_DIRS = []
+-LIBRARY_DIRS = []
++INCLUDE_DIRS = [os.environ['CONDA_HOME'] + '/include']
++LIBRARY_DIRS = [os.environ['CONDA_HOME'] + '/lib']
+ if sys.platform == 'darwin':
+     # putting here both macports and homebrew paths will generate
+     # "ld: warning: dir not found" at the linking phase 


### PR DESCRIPTION
Based on issue #26 this pull request adds a conda recipe that can be used to build self contained conda package on linux (windows/mac not yet tested)

The conda package can be build via:
```
conda build conda-recipe
```

__Note__: this recipe patches the compiler flags in setup.py (replace -Ofast with -ffast-math) as -Ofast does not work with old gcc versions (both flags do the same as far as I know)
