### PR TITLE
Add type casts to avoid gcc4.9.x compile errors

### DIFF
--- a/src/bitshuffle.c
+++ b/src/bitshuffle.c
@@ -168,8 +168,8 @@ int64_t bshuf_trans_bit_byte_remainder(void* in, void* out, const size_t size,
          const size_t elem_size, const size_t start_byte) {
 
     int ii, kk;
-    uint64_t* in_b = in;
-    uint8_t* out_b = out;
+    uint64_t* in_b = (uint64_t*) in;
+    uint8_t* out_b = (uint8_t*) out;
 
     uint64_t x, t;
 
@@ -1199,7 +1199,7 @@ int64_t bshuf_bitunshuffle_block(ioc_chain* C_ptr,
 /* Write a 64 bit unsigned integer to a buffer in big endian order. */
 void bshuf_write_uint64_BE(void* buf, uint64_t num) {
     int ii;
-    uint8_t* b = buf;
+    uint8_t* b = (uint8_t*) buf;
     uint64_t pow28 = 1 << 8;
     for (ii = 7; ii >= 0; ii--) {
         b[ii] = num % pow28;
@@ -1211,7 +1211,7 @@ void bshuf_write_uint64_BE(void* buf, uint64_t num) {
 /* Read a 64 bit unsigned integer from a buffer big endian order. */
 uint64_t bshuf_read_uint64_BE(void* buf) {
     int ii;
-    uint8_t* b = buf;
+    uint8_t* b = (uint8_t*) buf;
     uint64_t num = 0, pow28 = 1 << 8, cp = 1;
     for (ii = 7; ii >= 0; ii--) {
         num += b[ii] * cp;
@@ -1224,7 +1224,7 @@ uint64_t bshuf_read_uint64_BE(void* buf) {
 /* Write a 32 bit unsigned integer to a buffer in big endian order. */
 void bshuf_write_uint32_BE(void* buf, uint32_t num) {
     int ii;
-    uint8_t* b = buf;
+    uint8_t* b = (uint8_t*) buf;
     uint32_t pow28 = 1 << 8;
     for (ii = 3; ii >= 0; ii--) {
         b[ii] = num % pow28;
@@ -1236,7 +1236,7 @@ void bshuf_write_uint32_BE(void* buf, uint32_t num) {
 /* Read a 32 bit unsigned integer from a buffer big endian order. */
 uint32_t bshuf_read_uint32_BE(void* buf) {
     int ii;
-    uint8_t* b = buf;
+    uint8_t* b = (uint8_t*) buf;
     uint32_t num = 0, pow28 = 1 << 8, cp = 1;
     for (ii = 3; ii >= 0; ii--) {
         num += b[ii] * cp;
@@ -1272,7 +1272,7 @@ int64_t bshuf_compress_lz4_block(ioc_chain *C_ptr,
         free(tmp_buf_bshuf);
         return count;
     }
-    nbytes = LZ4_compress(tmp_buf_bshuf, tmp_buf_lz4, size * elem_size);
+    nbytes = LZ4_compress((const char*) tmp_buf_bshuf, (char*) tmp_buf_lz4, size * elem_size);
     free(tmp_buf_bshuf);
     CHECK_ERR_FREE_LZ(nbytes, tmp_buf_lz4);
 
@@ -1308,14 +1308,14 @@ int64_t bshuf_decompress_lz4_block(ioc_chain *C_ptr,
     if (tmp_buf == NULL) return -1;
 
 #ifdef BSHUF_LZ4_DECOMPRESS_FAST
-    nbytes = LZ4_decompress_fast((char*) in + 4, tmp_buf, size * elem_size);
+    nbytes = LZ4_decompress_fast((const char*) in + 4, (char*) tmp_buf, size * elem_size);
     CHECK_ERR_FREE_LZ(nbytes, tmp_buf);
     if (nbytes != nbytes_from_header) {
         free(tmp_buf);
         return -91;
     }
 #else
-    nbytes = LZ4_decompress_safe((char*) in + 4, tmp_buf, nbytes_from_header,
+    nbytes = LZ4_decompress_safe((const char*) in + 4, (char *) tmp_buf, nbytes_from_header,
                                  size * elem_size);
     CHECK_ERR_FREE_LZ(nbytes, tmp_buf);
     if (nbytes != size * elem_size) {


### PR DESCRIPTION
Hi,

I found some compile errors in g++ (Homebrew gcc49 4.9.2_1) 4.9.2.
Could you check this?

```
bitshuffle.c: In function 'int64_t bshuf_trans_bit_byte_remainder(void*, void*, size_t, size_t, size_t)':
bitshuffle.c:171:22: error: invalid conversion from 'void*' to 'uint64_t* {aka long long unsigned int*}' [-fpermissive]
     uint64_t* in_b = in;
                      ^
bitshuffle.c:172:22: error: invalid conversion from 'void*' to 'uint8_t* {aka unsigned char*}' [-fpermissive]
     uint8_t* out_b = out;
                      ^
bitshuffle.c: In function 'void bshuf_write_uint64_BE(void*, uint64_t)':
bitshuffle.c:1202:18: error: invalid conversion from 'void*' to 'uint8_t* {aka unsigned char*}' [-fpermissive]
     uint8_t* b = buf;
                  ^
bitshuffle.c: In function 'uint64_t bshuf_read_uint64_BE(void*)':
bitshuffle.c:1214:18: error: invalid conversion from 'void*' to 'uint8_t* {aka unsigned char*}' [-fpermissive]
     uint8_t* b = buf;
                  ^
bitshuffle.c: In function 'void bshuf_write_uint32_BE(void*, uint32_t)':
bitshuffle.c:1227:18: error: invalid conversion from 'void*' to 'uint8_t* {aka unsigned char*}' [-fpermissive]
     uint8_t* b = buf;
                  ^
bitshuffle.c: In function 'uint32_t bshuf_read_uint32_BE(void*)':
bitshuffle.c:1239:18: error: invalid conversion from 'void*' to 'uint8_t* {aka unsigned char*}' [-fpermissive]
     uint8_t* b = buf;
                  ^
bitshuffle.c: In function 'int64_t bshuf_compress_lz4_block(ioc_chain*, size_t, size_t)':
bitshuffle.c:1275:71: error: invalid conversion from 'void*' to 'const char*' [-fpermissive]
     nbytes = LZ4_compress(tmp_buf_bshuf, tmp_buf_lz4, size * elem_size);
                                                                       ^
In file included from bitshuffle.c:14:0:
../lz4/lz4.h:72:5: note: initializing argument 1 of 'int LZ4_compress(const char*, char*, int)'
 int LZ4_compress        (const char* source, char* dest, int sourceSize);
     ^
bitshuffle.c:1275:71: error: invalid conversion from 'void*' to 'char*' [-fpermissive]
     nbytes = LZ4_compress(tmp_buf_bshuf, tmp_buf_lz4, size * elem_size);
                                                                       ^
In file included from bitshuffle.c:14:0:
../lz4/lz4.h:72:5: note: initializing argument 2 of 'int LZ4_compress(const char*, char*, int)'
 int LZ4_compress        (const char* source, char* dest, int sourceSize);
     ^
bitshuffle.c: In function 'int64_t bshuf_decompress_lz4_block(ioc_chain*, size_t, size_t)':
bitshuffle.c:1311:75: error: invalid conversion from 'void*' to 'char*' [-fpermissive]
     nbytes = LZ4_decompress_fast((char*) in + 4, tmp_buf, size * elem_size);
                                                                           ^
In file included from bitshuffle.c:14:0:
../lz4/lz4.h:153:5: note: initializing argument 2 of 'int LZ4_decompress_fast(const char*, char*, int)'
 int LZ4_decompress_fast (const char* source, char* dest, int originalSize);
```