### PR TITLE
Compiler flags -Ofast -> -ffast-math. Works with older compliers.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -172,7 +172,6 @@ The conda package can be build via:
 ::
     conda build conda-recipe
 
-**Note:** this recipe patches the compiler flags in setup.py (replace -Ofast with -ffast-math) as -Ofast does not work with old gcc versions (both flags do the same as far as I know)
 
 For Best Results
 ----------------

--- a/conda-recipe/setup.py.patch
+++ b/conda-recipe/setup.py.patch
@@ -1,14 +1,5 @@
 --- setup.py	2016-01-19 16:56:12.954563000 +0100
 +++ xxx.py	2016-01-19 16:56:00.817087000 +0100
-@@ -24,7 +24,7 @@
-     VERSION = VERSION + ".dev%d" % VERSION_DEV
- 
- 
--COMPILE_FLAGS = ['-Ofast', '-march=native', '-std=c99', '-fopenmp']
-+COMPILE_FLAGS = ['-ffast-math', '-march=native', '-std=c99', '-fopenmp']
- # Cython breaks strict aliasing rules.
- COMPILE_FLAGS += ["-fno-strict-aliasing"]
- #COMPILE_FLAGS = ['-Ofast', '-march=core2', '-std=c99', '-fopenmp']
 @@ -40,8 +40,8 @@
  
  # Copied from h5py.

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ if VERSION_DEV:
     VERSION = VERSION + ".dev%d" % VERSION_DEV
 
 
-COMPILE_FLAGS = ['-Ofast', '-march=native', '-std=c99', '-fopenmp']
+COMPILE_FLAGS = ['-O3', '-ffast-math', '-march=native', '-std=c99', '-fopenmp']
 # Cython breaks strict aliasing rules.
 COMPILE_FLAGS += ["-fno-strict-aliasing"]
 #COMPILE_FLAGS = ['-Ofast', '-march=core2', '-std=c99', '-fopenmp']


### PR DESCRIPTION
This closes #33.