### PR TITLE
making openmp support optional, with a flag in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from Cython.Distutils import build_ext
 import numpy as np
 import h5py
 
-OPENMP_ENABLED = True
+OPENMP_ENABLED = 0
 
 VERSION_MAJOR = 0
 VERSION_MINOR = 2
@@ -27,11 +27,20 @@ VERSION = "%d.%d.%d" % (VERSION_MAJOR, VERSION_MINOR, VERSION_POINT)
 if VERSION_DEV:
     VERSION = VERSION + ".dev%d" % VERSION_DEV
 
+if os.getenv('OPENMP_ENABLED'):
+    try:
+        OPENMP_ENABLED = int(os.getenv('OPENMP_ENABLED'))
+    except:
+        print("[ERROR] OPENMP_ENABLED variable can be only 0 (disabled) or 1 (enabled)")
+        sys.exit(-1)
 
 COMPILE_FLAGS = ['-O3', '-ffast-math', '-march=native', '-std=c99']
 
 # adding OpenMP 
-if OPENMP_ENABLED and 'darwin' not in sys.platform:
+if OPENMP_ENABLED:
+    print("\n#################################")
+    print("# Compiling with OpenMP support #")
+    print("#################################\n")
     COMPILE_FLAGS += ['-fopenmp']
 
 # Cython breaks strict aliasing rules.

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from Cython.Distutils import build_ext
 import numpy as np
 import h5py
 
-OPENMP_ENABLED = False
+OPENMP_ENABLED = True
 
 VERSION_MAJOR = 0
 VERSION_MINOR = 2

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,8 @@ from Cython.Distutils import build_ext
 import numpy as np
 import h5py
 
+OPENMP_ENABLED = False
+
 VERSION_MAJOR = 0
 VERSION_MINOR = 2
 VERSION_POINT = 3
@@ -26,7 +28,12 @@ if VERSION_DEV:
     VERSION = VERSION + ".dev%d" % VERSION_DEV
 
 
-COMPILE_FLAGS = ['-O3', '-ffast-math', '-march=native', '-std=c99', '-fopenmp']
+COMPILE_FLAGS = ['-O3', '-ffast-math', '-march=native', '-std=c99']
+
+# adding OpenMP 
+if OPENMP_ENABLED and 'darwin' not in sys.platform:
+    COMPILE_FLAGS += ['-fopenmp']
+
 # Cython breaks strict aliasing rules.
 COMPILE_FLAGS += ["-fno-strict-aliasing"]
 #COMPILE_FLAGS = ['-Ofast', '-march=core2', '-std=c99', '-fopenmp']


### PR DESCRIPTION
Hallo,

this pull request is just because OpenMP interferes with how we are using this module atm (within a multi-threaded software). It just introduces a flag for enabling OpenMP or not. 

It also takes into account the case reported in the pull request #38 by @graeme-winter . Hope this can be useful, let me know if you prefer this to be implemented differently

Thanks!