### PR TITLE
Changes to allow compilation of bitshuffle C code with VS2008.

### DIFF
--- a/src/bitshuffle.c
+++ b/src/bitshuffle.c
@@ -13,9 +13,18 @@
 #include "bitshuffle_core.h"
 #include "bitshuffle_internals.h"
 #include "lz4.h"
+#if defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)   /* C99 */
+# include <stdint.h>
+#else
+  typedef unsigned char       uint8_t;
+  typedef unsigned short      uint16_t;
+  typedef unsigned int        uint32_t;
+  typedef signed int        int32_t;
+  typedef unsigned long long  uint64_t;
+  typedef long long           int64_t;
+#endif
 
 #include <stdio.h>
-#include <stdint.h>
 #include <string.h>
 
 
@@ -30,23 +39,26 @@
 
 
 /* Bitshuffle and compress a single block. */
-int64_t bshuf_compress_lz4_block(ioc_chain *C_ptr,
+int64_t bshuf_compress_lz4_block(ioc_chain *C_ptr, \
         const size_t size, const size_t elem_size) {
 
     int64_t nbytes, count;
+    void *tmp_buf_bshuf;
+    void *tmp_buf_lz4;
+    size_t this_iter;
+    void *in, *out;
 
-    void* tmp_buf_bshuf = malloc(size * elem_size);
+    tmp_buf_bshuf = malloc(size * elem_size);
     if (tmp_buf_bshuf == NULL) return -1;
 
-    void* tmp_buf_lz4 = malloc(LZ4_compressBound(size * elem_size));
+    tmp_buf_lz4 = malloc(LZ4_compressBound(size * elem_size));
     if (tmp_buf_lz4 == NULL){
         free(tmp_buf_bshuf);
         return -1;
     }
 
-    size_t this_iter;
 
-    void *in = ioc_get_in(C_ptr, &this_iter);
+    in = ioc_get_in(C_ptr, &this_iter);
     ioc_set_next_in(C_ptr, &this_iter, (void*) ((char*) in + size * elem_size));
 
     count = bshuf_trans_bit_elem(in, tmp_buf_bshuf, size, elem_size);
@@ -59,7 +71,7 @@ int64_t bshuf_compress_lz4_block(ioc_chain *C_ptr,
     free(tmp_buf_bshuf);
     CHECK_ERR_FREE_LZ(nbytes, tmp_buf_lz4);
 
-    void *out = ioc_get_out(C_ptr, &this_iter);
+    out = ioc_get_out(C_ptr, &this_iter);
     ioc_set_next_out(C_ptr, &this_iter, (void *) ((char *) out + nbytes + 4));
 
     bshuf_write_uint32_BE(out, nbytes);
@@ -76,18 +88,20 @@ int64_t bshuf_decompress_lz4_block(ioc_chain *C_ptr,
         const size_t size, const size_t elem_size) {
 
     int64_t nbytes, count;
-
+    void *in, *out, *tmp_buf;
     size_t this_iter;
-    void *in = ioc_get_in(C_ptr, &this_iter);
-    int32_t nbytes_from_header = bshuf_read_uint32_BE(in);
+    int32_t nbytes_from_header;
+
+    in = ioc_get_in(C_ptr, &this_iter);
+    nbytes_from_header = bshuf_read_uint32_BE(in);
     ioc_set_next_in(C_ptr, &this_iter,
             (void*) ((char*) in + nbytes_from_header + 4));
 
-    void *out = ioc_get_out(C_ptr, &this_iter);
+    out = ioc_get_out(C_ptr, &this_iter);
     ioc_set_next_out(C_ptr, &this_iter,
             (void *) ((char *) out + size * elem_size));
 
-    void* tmp_buf = malloc(size * elem_size);
+    tmp_buf = malloc(size * elem_size);
     if (tmp_buf == NULL) return -1;
 
 #ifdef BSHUF_LZ4_DECOMPRESS_FAST

--- a/src/bitshuffle.c
+++ b/src/bitshuffle.c
@@ -13,16 +13,6 @@
 #include "bitshuffle_core.h"
 #include "bitshuffle_internals.h"
 #include "lz4.h"
-#if defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)   /* C99 */
-# include <stdint.h>
-#else
-  typedef unsigned char       uint8_t;
-  typedef unsigned short      uint16_t;
-  typedef unsigned int        uint32_t;
-  typedef signed int        int32_t;
-  typedef unsigned long long  uint64_t;
-  typedef long long           int64_t;
-#endif
 
 #include <stdio.h>
 #include <string.h>

--- a/src/bitshuffle.h
+++ b/src/bitshuffle.h
@@ -27,17 +27,6 @@
 
 #ifndef BITSHUFFLE_H
 #define BITSHUFFLE_H
-#if defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)   /* C99 */
-# include <stdint.h>
-#else
-  typedef unsigned char       uint8_t;
-  typedef unsigned short      uint16_t;
-  typedef unsigned int        uint32_t;
-  typedef   signed int        int32_t;
-  typedef unsigned long long  uint64_t;
-  typedef long long           int64_t;
-#endif
-
 
 #include <stdlib.h>
 #include "bitshuffle_core.h"

--- a/src/bitshuffle.h
+++ b/src/bitshuffle.h
@@ -27,9 +27,18 @@
 
 #ifndef BITSHUFFLE_H
 #define BITSHUFFLE_H
+#if defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)   /* C99 */
+# include <stdint.h>
+#else
+  typedef unsigned char       uint8_t;
+  typedef unsigned short      uint16_t;
+  typedef unsigned int        uint32_t;
+  typedef   signed int        int32_t;
+  typedef unsigned long long  uint64_t;
+  typedef long long           int64_t;
+#endif
 
 
-#include <stdint.h>
 #include <stdlib.h>
 #include "bitshuffle_core.h"
 

--- a/src/bitshuffle_core.h
+++ b/src/bitshuffle_core.h
@@ -28,8 +28,17 @@
 #ifndef BITSHUFFLE_CORE_H
 #define BITSHUFFLE_CORE_H
 
+#if defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)   /* C99 */
+# include <stdint.h>
+#else
+  typedef unsigned char       uint8_t;
+  typedef unsigned short      uint16_t;
+  typedef unsigned int        uint32_t;
+  typedef   signed int        int32_t;
+  typedef unsigned long long  uint64_t;
+  typedef long long           int64_t;
+#endif
 
-#include <stdint.h>
 #include <stdlib.h>
 
 

--- a/src/bitshuffle_internals.h
+++ b/src/bitshuffle_internals.h
@@ -13,8 +13,17 @@
 #ifndef BITSHUFFLE_INTERNALS_H
 #define BITSHUFFLE_INTERNALS_H
 
+#if defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)   /* C99 */
+# include <stdint.h>
+#else
+  typedef unsigned char       uint8_t;
+  typedef unsigned short      uint16_t;
+  typedef unsigned int        uint32_t;
+  typedef   signed int        int32_t;
+  typedef unsigned long long  uint64_t;
+  typedef long long           int64_t;
+#endif
 
-#include <stdint.h>
 #include <stdlib.h>
 #include "iochain.h"
 

--- a/src/bshuf_h5filter.c
+++ b/src/bshuf_h5filter.c
@@ -101,6 +101,7 @@ size_t bshuf_h5_filter(unsigned int flags, size_t cd_nelmts,
     size_t block_size = 0;
     size_t buf_size_out, nbytes_uncomp, nbytes_out;
     char* in_buf = *buf;
+    void *out_buf;
 
     if (cd_nelmts < 3) {
         PUSH_ERR("bshuf_h5_filter", H5E_CALLBACK, 
@@ -143,7 +144,6 @@ size_t bshuf_h5_filter(unsigned int flags, size_t cd_nelmts,
     }
     size = nbytes_uncomp / elem_size;
 
-    void* out_buf;
     out_buf = malloc(buf_size_out);
     if (out_buf == NULL) {
         PUSH_ERR("bshuf_h5_filter", H5E_CALLBACK, 


### PR DESCRIPTION
These changes are needed in order to make the bitshuffle code compatible with VS2008. Basically one has to replace stdint.h and, in the functions, make the type declarations prior to the other statements.