### PR TITLE
Big endian support 

### DIFF
--- a/src/bitshuffle_core.c
+++ b/src/bitshuffle_core.c
@@ -159,17 +159,31 @@ int64_t bshuf_trans_bit_byte_remainder(const void* in, void* out, const size_t s
 
     uint64_t x, t;
 
+    uint64_t e=1;
+    int little_endian = *(uint8_t *) &e == 1;
+
     size_t nbyte = elem_size * size;
     size_t nbyte_bitrow = nbyte / 8;
+    size_t bit_row_skip, bit_row_offset;
 
     CHECK_MULT_EIGHT(nbyte);
     CHECK_MULT_EIGHT(start_byte);
+
+
+    if (little_endian) {
+        bit_row_skip = nbyte_bitrow;
+        bit_row_offset = 0;
+    } else {
+        bit_row_skip = -nbyte_bitrow;
+        bit_row_offset = 8 * nbyte_bitrow;
+    }
+
 
     for (ii = start_byte / 8; ii < nbyte_bitrow; ii ++) {
         x = in_b[ii];
         TRANS_BIT_8X8(x, t);
         for (kk = 0; kk < 8; kk ++) {
-            out_b[kk * nbyte_bitrow + ii] = x;
+            out_b[bit_row_offset + kk * bit_row_skip + ii] = x;
             x = x >> 8;
         }
     }

--- a/src/bitshuffle_core.c
+++ b/src/bitshuffle_core.c
@@ -153,19 +153,19 @@ int64_t bshuf_trans_byte_elem_scal(const void* in, void* out, const size_t size,
 int64_t bshuf_trans_bit_byte_remainder(const void* in, void* out, const size_t size,
          const size_t elem_size, const size_t start_byte) {
 
-    int ii, kk;
     const uint64_t* in_b = (const uint64_t*) in;
     uint8_t* out_b = (uint8_t*) out;
 
     uint64_t x, t;
 
-    uint64_t e=1;
-    int little_endian = *(uint8_t *) &e == 1;
-
+    size_t ii, kk;
     size_t nbyte = elem_size * size;
     size_t nbyte_bitrow = nbyte / 8;
     size_t bit_row_offset;
     int64_t bit_row_skip;
+
+    uint64_t e=1;
+    int little_endian = *(uint8_t *) &e == 1;
 
     CHECK_MULT_EIGHT(nbyte);
     CHECK_MULT_EIGHT(start_byte);
@@ -175,7 +175,7 @@ int64_t bshuf_trans_bit_byte_remainder(const void* in, void* out, const size_t s
         bit_row_offset = 0;
     } else {
         bit_row_skip = -nbyte_bitrow;
-        bit_row_offset = 8 * nbyte_bitrow;
+        bit_row_offset = 7 * nbyte_bitrow;
     }
 
     for (ii = start_byte / 8; ii < nbyte_bitrow; ii ++) {
@@ -283,17 +283,30 @@ int64_t bshuf_trans_byte_bitrow_scal(const void* in, void* out, const size_t siz
 int64_t bshuf_shuffle_bit_eightelem_scal(const void* in, void* out, \
         const size_t size, const size_t elem_size) {
 
-    size_t ii, jj, kk;
     const char *in_b;
     char *out_b;
     uint64_t x, t;
-    size_t nbyte;
+    size_t ii, jj, kk;
+    size_t nbyte, out_index;
 
+    uint64_t e=1;
+    int little_endian = *(uint8_t *) &e == 1;
+
+    size_t elem_offset;
+    uint64_t elem_skip;
 
     CHECK_MULT_EIGHT(size);
 
     in_b = (const char*) in;
     out_b = (char*) out;
+
+    if (little_endian) {
+        elem_skip = elem_size;
+        elem_offset = 0;
+    } else {
+        elem_skip = -elem_size;
+        elem_offset = 7 * elem_size;
+    }
 
     nbyte = elem_size * size;
 
@@ -302,7 +315,8 @@ int64_t bshuf_shuffle_bit_eightelem_scal(const void* in, void* out, \
             x = *((uint64_t*) &in_b[ii + jj]);
             TRANS_BIT_8X8(x, t);
             for (kk = 0; kk < 8; kk++) {
-                *((uint8_t*) &out_b[ii + jj / 8 + kk * elem_size]) = x;
+                out_index = ii + jj / 8 + elem_offset + kk * elem_skip;
+                *((uint8_t*) &out_b[out_index]) = x;
                 x = x >> 8;
             }
         }

--- a/src/bitshuffle_core.c
+++ b/src/bitshuffle_core.c
@@ -164,11 +164,11 @@ int64_t bshuf_trans_bit_byte_remainder(const void* in, void* out, const size_t s
 
     size_t nbyte = elem_size * size;
     size_t nbyte_bitrow = nbyte / 8;
-    size_t bit_row_skip, bit_row_offset;
+    size_t bit_row_offset;
+    int64_t bit_row_skip;
 
     CHECK_MULT_EIGHT(nbyte);
     CHECK_MULT_EIGHT(start_byte);
-
 
     if (little_endian) {
         bit_row_skip = nbyte_bitrow;
@@ -177,7 +177,6 @@ int64_t bshuf_trans_bit_byte_remainder(const void* in, void* out, const size_t s
         bit_row_skip = -nbyte_bitrow;
         bit_row_offset = 8 * nbyte_bitrow;
     }
-
 
     for (ii = start_byte / 8; ii < nbyte_bitrow; ii ++) {
         x = in_b[ii];

--- a/src/bitshuffle_core.h
+++ b/src/bitshuffle_core.h
@@ -45,8 +45,8 @@
 // These are usually set in the setup.py.
 #ifndef BSHUF_VERSION_MAJOR
 #define BSHUF_VERSION_MAJOR 0
-#define BSHUF_VERSION_MINOR 2
-#define BSHUF_VERSION_POINT 5
+#define BSHUF_VERSION_MINOR 3
+#define BSHUF_VERSION_POINT 0
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR is an alternative approach to kiyo-masui/bitshuffle#56. Instead of swapping bytes on BE, this uses a new bit-transpose macro `TRANS_BIT_8X8_BE`, together with the changes in the commit e29fafec2700194b22dcd39a154f0f7767951181 (which changes the order to store the 8x8-bit-transpose results based on the endianness).

This produces the same bit-by-bit results with the same overhead on BE as on LE. Compared with e29fafec2700194b22dcd39a154f0f7767951181, it introduces conditional branches to check `little_endian` in the second-innermost loops. A compiler might be able to remove it, but if we really want to, we can rewrite the patch to do so with a bit duplicate and complicated code.

All of the tests in `nosetests bitshuffle` succeeded on Linux/x86_64 (LE) and Linux/s390x (BE).