### PR TITLE
Add a condition for GNU c++ in bitshuffle_core.h

### DIFF
--- a/src/bitshuffle_core.h
+++ b/src/bitshuffle_core.h
@@ -28,8 +28,9 @@
 #ifndef BITSHUFFLE_CORE_H
 #define BITSHUFFLE_CORE_H
 
-#if defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)   /* C99 */
-# include <stdint.h>
+// We assume GNU g++ defining `__cplusplus` has stdint.h
+#if (defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199900L) || defined(__cplusplus)
+#include <stdint.h>
 #else
   typedef unsigned char       uint8_t;
   typedef unsigned short      uint16_t;

--- a/src/bitshuffle_internals.h
+++ b/src/bitshuffle_internals.h
@@ -13,8 +13,9 @@
 #ifndef BITSHUFFLE_INTERNALS_H
 #define BITSHUFFLE_INTERNALS_H
 
-#if defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)   /* C99 */
-# include <stdint.h>
+// We assume GNU g++ defining `__cplusplus` has stdint.h
+#if (defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199900L) || defined(__cplusplus)
+#include <stdint.h>
 #else
   typedef unsigned char       uint8_t;
   typedef unsigned short      uint16_t;


### PR DESCRIPTION
We got an exception to compile `bitshuffle v0.3.1` with `g++`(https://github.com/xerial/snappy-java/pull/163).
This pr fixed this issue.