### PR TITLE
setup: allow virtualenv installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ os: linux
 #sudo: true
 python:
     - "2.7"
-    - "3.3"
     - "3.4"
     - "3.5"
+    - "3.6"
 addons:
     apt:
         packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,21 @@ addons:
             - libhdf5-serial-dev
             - hdf5-tools
 install:
+    - "pip install -U pip virtualenv"
+    # Ensures the system hdf5 headers/libs will be used whatever its version
+    - "export HDF5_DIR=/usr/lib"
     # Force Cython to be istalled before h5py.
     - "pip install Cython>=0.19"
-    - "pip install --no-use-wheel -r requirements.txt"
+    - "pip install --no-binary=h5py -r requirements.txt"
     # Installing the plugin to arbitrary directory to check the install script.
     - "python setup.py install --h5plugin --h5plugin-dir ~/hdf5/lib"
+    # Ensure it's installable and usable in virtualenv
+    - "virtualenv ~/venv"
+    - "travis_wait 30 ~/venv/bin/pip -v install --no-binary=h5py ."
+    - "~/venv/bin/pip -v install nose"
 # Can't be somewhere that has a 'bitshuffle' directory as nose will use that
 # copy instead of installed package.
-script: "cd ~; nosetests bitshuffle"
+script:
+  - "cd ~"
+  - "nosetests -v bitshuffle"  # Test the system install
+  - "venv/bin/nosetests -v bitshuffle"  # Test the virtualenv install

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
+# order matter
 setuptools>=0.7
-numpy>=1.6.1
 Cython>=0.19
+numpy>=1.6.1
 h5py>=2.4.0


### PR DESCRIPTION
Currently "pip install -e ." or "pip install bitshuffle" inside
a virtualenv fail. An application that just put bitshuffle into
its requirement will fail to install btshuffle due to missing python
libs (h5py/numpy/cython).

This change moves the install_requires into setup_reuires. So setuptools
will install the dependencies before build_ext/install/... Also this
lazy loads the ext_modules to ensure all dependencies are
installed before we cythonize them.