### PR TITLE
Require non-wheel install of h5py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,12 @@ install:
     # Ensures the system hdf5 headers/libs will be used whatever its version
     - "export HDF5_DIR=/usr/lib"
     # Force Cython to be istalled before h5py.
-    - "pip install Cython>=0.19"
-    - "pip install --no-binary=h5py -r requirements.txt"
+    - "pip install -r requirements.txt"
     # Installing the plugin to arbitrary directory to check the install script.
     - "python setup.py install --h5plugin --h5plugin-dir ~/hdf5/lib"
     # Ensure it's installable and usable in virtualenv
     - "virtualenv ~/venv"
-    - "travis_wait 30 ~/venv/bin/pip -v install --no-binary=h5py ."
+    - "travis_wait 30 ~/venv/bin/pip -v install ."
     - "~/venv/bin/pip -v install nose"
 # Can't be somewhere that has a 'bitshuffle' directory as nose will use that
 # copy instead of installed package.

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,12 @@ install:
     - "pip install -U pip virtualenv"
     # Ensures the system hdf5 headers/libs will be used whatever its version
     - "export HDF5_DIR=/usr/lib"
-    # Force Cython to be istalled before h5py.
     - "pip install -r requirements.txt"
     # Installing the plugin to arbitrary directory to check the install script.
     - "python setup.py install --h5plugin --h5plugin-dir ~/hdf5/lib"
     # Ensure it's installable and usable in virtualenv
     - "virtualenv ~/venv"
-    - "travis_wait 30 ~/venv/bin/pip -v install ."
+    - "travis_wait 30 ~/venv/bin/pip -v install --no-binary=h5py ."
     - "~/venv/bin/pip -v install nose"
 # Can't be somewhere that has a 'bitshuffle' directory as nose will use that
 # copy instead of installed package.

--- a/README.rst
+++ b/README.rst
@@ -47,9 +47,12 @@ As a bonus, Bitshuffle ships with a dynamically loaded version of
 `h5py`'s LZF compression filter, such that the filter can be transparently
 used outside of python and in command line utilities such as ``h5dump``.
 
-.. [1] Chosen to fit comfortably within L1 cache as well as be well matched window of the LZF compression library.
+.. [1] Chosen to fit comfortably within L1 cache as well as be well matched
+       window of the LZF compression library.
 
-.. [2] Over applying bitshuffle to the full dataset then applying LZ4 compression, this has the tremendous advantage that the block is already in the L1 cache.
+.. [2] Over applying bitshuffle to the full dataset then applying LZ4
+       compression, this has the tremendous advantage that the block is
+       already in the L1 cache.
 
 .. _`dynamically loaded filters`: http://www.hdfgroup.org/HDF5/doc/Advanced/DynamicallyLoadedFilters/HDF5DynamicallyLoadedFilters.pdf
 
@@ -92,9 +95,11 @@ Comparing Bitshuffle to other compression algorithms and HDF5 filters:
 Installation for Python
 -----------------------
 
-Installation requires python 2.7+ or 3.3+, HDF5 1.8 or later, HDF5 for python,
-Numpy and Cython.  To use the dynamically loaded HDF5 filter requires HDF5
-1.8.11 or later.
+Installation requires python 2.7+ or 3.3+, HDF5 1.8.4 or later, HDF5 for python
+(h5py), Numpy and Cython. Bitshuffle must be linked against the same version of
+HDF5 as h5py, which in practice means h5py must be built from source_ rather
+than pre-built wheels [3]_. To use the dynamically loaded HDF5 filter requires
+HDF5 1.8.11 or later.
 
 To install::
 
@@ -112,6 +117,11 @@ search location of ``/usr/local/hdf5/lib/plugin``.
 If you get an error about missing source files when building the extensions,
 try upgrading setuptools.  There is a weird bug where setuptools prior to 0.7
 doesn't work properly with Cython in some cases.
+
+.. _source: http://docs.h5py.org/en/latest/build.html#source-installation
+
+.. [3] Typically you will be able to install Bitshuffle, but there will be
+       errors when creating and reading datasets.
 
 
 Usage from Python

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# order matter
+# Order matters
 setuptools>=0.7
 Cython>=0.19
 numpy>=1.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@
 setuptools>=0.7
 Cython>=0.19
 numpy>=1.6.1
-h5py>=2.4.0
+h5py>=2.4.0 --no-binary=h5py

--- a/setup.py
+++ b/setup.py
@@ -271,6 +271,7 @@ else:
 
 with open('requirements.txt') as f:
     requires = f.read().splitlines()
+    requires = [r.split()[0] for r in requires]
 
 # TODO hdf5 support should be an "extra". Figure out how to set this up.
 setup(


### PR DESCRIPTION
Require a non-wheel install of h5py until a fix for #52 and #53 is found.