### PR TITLE
CPATH is now searched to find the HDF5 headers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -155,7 +155,8 @@ lzf_plugin = Extension(
 EXTENSIONS = [ext_bshuf, h5filter]
 # Check for plugin hdf5 plugin support (hdf5 >= 1.8.11)
 HDF5_PLUGIN_SUPPORT = False
-for p in ["/usr/include"] + pkgconfig("hdf5")["include_dirs"]:
+CPATHS = os.environ['CPATH'].split(':') if 'CPATH' in os.environ else []
+for p in ["/usr/include"] + pkgconfig("hdf5")["include_dirs"] + CPATHS:
     if os.path.exists(os.path.join(p, "H5PLextern.h")):
         HDF5_PLUGIN_SUPPORT = True
 


### PR DESCRIPTION
Made `setup.py` search `CPATH` for the headers to allow for custom installs without writing your own `.pc` file.