### PR TITLE
using signed 64-bit integer for OpenMP under MSVC

### DIFF
--- a/src/bitshuffle_core.c
+++ b/src/bitshuffle_core.c
@@ -33,7 +33,7 @@
 #endif
 
 #if defined(_OPENMP) && defined(_MSC_VER)
-typedef uint64_t omp_size_t;
+typedef int64_t omp_size_t;
 #else
 typedef size_t omp_size_t;
 #endif
@@ -1143,7 +1143,7 @@ int64_t bshuf_untrans_bit_elem(const void* in, void* out, const size_t size,
 int64_t bshuf_blocked_wrap_fun(bshufBlockFunDef fun, const void* in, void* out, \
         const size_t size, const size_t elem_size, size_t block_size) {
 
-    omp_size_t ii;
+    omp_size_t ii = 0;
     int64_t err = 0;
     int64_t count, cum_count=0;
     size_t last_block_size;

--- a/src/bitshuffle_core.c
+++ b/src/bitshuffle_core.c
@@ -32,6 +32,11 @@
 #include <emmintrin.h>
 #endif
 
+#if defined(_OPENMP) && defined(_MSC_VER)
+typedef uint64_t omp_size_t
+#else
+typedef size_t omp_size_t
+#endif
 
 // Macros.
 #define CHECK_MULT_EIGHT(n) if (n % 8) return -80;
@@ -1138,7 +1143,7 @@ int64_t bshuf_untrans_bit_elem(const void* in, void* out, const size_t size,
 int64_t bshuf_blocked_wrap_fun(bshufBlockFunDef fun, const void* in, void* out, \
         const size_t size, const size_t elem_size, size_t block_size) {
 
-    size_t ii;
+    omp_size_t ii;
     int64_t err = 0;
     int64_t count, cum_count=0;
     size_t last_block_size;
@@ -1161,7 +1166,7 @@ int64_t bshuf_blocked_wrap_fun(bshufBlockFunDef fun, const void* in, void* out, 
     #pragma omp parallel for schedule(dynamic, 1) \
             private(count) reduction(+ : cum_count)
 #endif
-    for (ii = 0; ii < size / block_size; ii ++) {
+    for (ii = 0; ii < (omp_size_t)( size / block_size ); ii ++) {
         count = fun(&C, block_size, elem_size);
         if (count < 0) err = count;
         cum_count += count;

--- a/src/bitshuffle_core.c
+++ b/src/bitshuffle_core.c
@@ -33,9 +33,9 @@
 #endif
 
 #if defined(_OPENMP) && defined(_MSC_VER)
-typedef uint64_t omp_size_t
+typedef uint64_t omp_size_t;
 #else
-typedef size_t omp_size_t
+typedef size_t omp_size_t;
 #endif
 
 // Macros.


### PR DESCRIPTION
MSVC doesn't like `size_t` in parallel for loops, this simple typedef fixes this.