### PR TITLE
only use NEON for aarch64

### DIFF
--- a/src/bitshuffle_core.c
+++ b/src/bitshuffle_core.c
@@ -25,7 +25,9 @@
 #endif
 
 #if defined(__ARM_NEON__) || (__ARM_NEON)
+#ifdef __aarch64__
 #define USEARMNEON
+#endif
 #endif
 
 // Conditional includes for SSE2 and AVX2.


### PR DESCRIPTION
fixes #72 