### PR TITLE
Fix memory alllocation

### DIFF
--- a/src/bshuf_h5filter.h
+++ b/src/bshuf_h5filter.h
@@ -42,7 +42,7 @@
 #define BSHUF_H5_COMPRESS_LZ4 2
 
 
-extern H5Z_class_t bshuf_H5Filter[1];
+H5_DLLVAR H5Z_class_t bshuf_H5Filter[1];
 
 
 /* ---- bshuf_register_h5filter ----


### PR DESCRIPTION
Replace malloc() and free() in bshuf_h5filter.c with H5allocate_memory() and H5free_memory().  This is the correct way to do it according to the HDF Group.

Fix to bshuf_h5filter.h to work on Windows.
