### PR TITLE
Enable compilation/optimisation on powerpc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ from setuptools.command.install import install as install_
 import shutil
 import subprocess
 import sys
+import platform
 
 
 VERSION_MAJOR = 0
@@ -273,7 +274,13 @@ class build_ext(build_ext_):
                 compileflags = COMPILE_FLAGS_MSVC
             else:
                 openmpflag = '-fopenmp'
-                compileflags = COMPILE_FLAGS + ['-march=%s' % self.march]
+                archi = platform.machine() 
+                if archi in ('i386', 'x86_64'):
+                    compileflags = COMPILE_FLAGS + ['-march=%s' % self.march]
+                else:
+                    compileflags = COMPILE_FLAGS + ['-mcpu=%s' % self.march]
+                    if archi == 'ppc64le':
+                        compileflags = COMPILE_FLAGS + ["-DNO_WARN_X86_INTRINSICS"]
             for e in self.extensions:
                 e.extra_compile_args = list(set(e.extra_compile_args).union(compileflags))
                 if openmpflag not in e.extra_compile_args:

--- a/src/bitshuffle_core.c
+++ b/src/bitshuffle_core.c
@@ -20,7 +20,7 @@
 #define USEAVX2
 #endif
 
-#if defined(__SSE2__)
+#if defined(__SSE2__) || defined(NO_WARN_X86_INTRINSICS)
 #define USESSE2
 #endif
 


### PR DESCRIPTION
On PowerPC, gcc and clang offer an automatic translation of the SSE2 code to Altivec.

For arm32 and arm64, both `mcpu` and `march` options are available.
On intel x86 computers, `mcpu` does not exist.
On PowerPC, `march` option does not exist.
For other architectures (mips, ...), mcpu is more likely to be present.