### PR TITLE
Fix tests

### DIFF
--- a/bitshuffle/tests/test_h5filter.py
+++ b/bitshuffle/tests/test_h5filter.py
@@ -23,7 +23,7 @@ class TestFilter(unittest.TestCase):
         dtype = np.int64
         data = np.arange(shape[0])
         fname = "tmp_test_filters.h5"
-        f = h5py.File(fname)
+        f = h5py.File(fname, "w")
         h5.create_dataset(f, b"range", shape, dtype, chunks,
                 filter_pipeline=(32008, 32000),
                 filter_flags=(h5z.FLAG_MANDATORY, h5z.FLAG_MANDATORY),
@@ -43,7 +43,7 @@ class TestFilter(unittest.TestCase):
         dtype = np.int64
         data = np.arange(shape[0])
         fname = "tmp_test_filters.h5"
-        f = h5py.File(fname)
+        f = h5py.File(fname, "w")
         h5.create_dataset(f, b"range", shape, dtype, chunks,
                 filter_pipeline=(32008, 32000),
                 filter_flags=(h5z.FLAG_MANDATORY, h5z.FLAG_MANDATORY),
@@ -65,7 +65,7 @@ class TestFilter(unittest.TestCase):
         dtype = np.int64
         data = np.arange(shape[0])
         fname = "tmp_test_filters.h5"
-        f = h5py.File(fname)
+        f = h5py.File(fname, "w")
         h5.create_dataset(f, b"range", shape, dtype, chunks,
                 filter_pipeline=(32008,),
                 filter_flags=(h5z.FLAG_MANDATORY,),

--- a/bitshuffle/tests/test_h5plugin.py
+++ b/bitshuffle/tests/test_h5plugin.py
@@ -34,8 +34,7 @@ class TestFilterPlugins(unittest.TestCase):
         dtype = np.int64
         data = np.arange(shape[0])
         fname = "tmp_test_filters.h5"
-        f = h5py.File(fname)
-        f = h5py.File(fname)
+        f = h5py.File(fname, "w")
         dset = f.create_dataset("range",
                 shape=shape,
                 dtype=dtype,


### PR DESCRIPTION
- test: open h5 files in write mode

Since h5py 3.0 the default is read only, which broke these tests.