### PR TITLE
Build bitshuffle wheels

### DIFF
--- a/.github/workflows/install_hdf5.sh
+++ b/.github/workflows/install_hdf5.sh
@@ -1,0 +1,10 @@
+# Download and install HDF5 1.10.7 from source for building wheels
+curl https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.7/src/hdf5-1.10.7.tar.gz --output hdf5-1.10.7.tar.gz --silent
+tar -xvf hdf5-1.10.7.tar.gz
+cd hdf5-1.10.7
+chmod +x autogen.sh
+./autogen.sh
+./configure --prefix=/usr/local
+make -j 6
+make install
+cd ..

--- a/.github/workflows/install_hdf5.sh
+++ b/.github/workflows/install_hdf5.sh
@@ -1,7 +1,9 @@
-# Download and install HDF5 1.10.7 from source for building wheels
-curl https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.7/src/hdf5-1.10.7.tar.gz --output hdf5-1.10.7.tar.gz --silent
-tar -xvf hdf5-1.10.7.tar.gz
-cd hdf5-1.10.7
+HDF5_VERSION=$1
+
+# Download and install HDF5 $HDF5_VERSION from source for building wheels
+curl https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${HDF5_VERSION%.*}/hdf5-$HDF5_VERSION/src/hdf5-$HDF5_VERSION.tar.gz --output hdf5-$HDF5_VERSION.tar.gz --silent
+tar -xvf hdf5-$HDF5_VERSION.tar.gz
+cd hdf5-$HDF5_VERSION
 chmod +x autogen.sh
 ./autogen.sh
 ./configure --prefix=/usr/local

--- a/.github/workflows/install_hdf5.sh
+++ b/.github/workflows/install_hdf5.sh
@@ -6,7 +6,7 @@ tar -xvf hdf5-$HDF5_VERSION.tar.gz
 cd hdf5-$HDF5_VERSION
 chmod +x autogen.sh
 ./autogen.sh
-./configure --prefix=/usr/local
+CFLAGS=-std=c99 ./configure --prefix=/usr/local
 make -j 6
 make install
 cd ..

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
+        hdf5: [1.8.11, 1.10.7]
 
     steps:
       # Checkout bitshuffle
@@ -22,10 +23,10 @@ jobs:
 
       # Build wheels for linux and x86 platforms
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
+        run: python -m cibuildwheel --output-dir wheelhouse-hdf5-${{ matrix.hdf5 }}
         env:
           CIBW_ARCHS_LINUX: "x86_64"
-          CIBW_BEFORE_ALL_LINUX: chmod +x .github/workflows/install_hdf5.sh; .github/workflows/install_hdf5.sh
+          CIBW_BEFORE_ALL_LINUX: chmod +x .github/workflows/install_hdf5.sh; .github/workflows/install_hdf5.sh ${{ matrix.hdf5 }}
           CIBW_ENVIRONMENT: "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib"
           CIBW_TEST_REQUIRES: pytest
           # Run units tests but disable test_h5plugin.py
@@ -34,4 +35,4 @@ jobs:
       # Package wheels and host on CI
       - uses: actions/upload-artifact@v2
         with:
-          path: ./wheelhouse/*.whl
+          path: ./wheelhouse-hdf5-${{ matrix.hdf5 }}/*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -4,12 +4,12 @@ on: [pull_request]
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.os }} and hdf5-${{ matrix.hdf5 }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest]
-        hdf5: [1.8.11, 1.10.7]
+        hdf5: [1.10.7]
 
     steps:
       # Checkout bitshuffle
@@ -29,6 +29,7 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: chmod +x .github/workflows/install_hdf5.sh; .github/workflows/install_hdf5.sh ${{ matrix.hdf5 }}
           CIBW_ENVIRONMENT: "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib"
           CIBW_TEST_REQUIRES: pytest
+          CIBW_BEFORE_TEST: chmod +x .github/workflows/install_hdf5.sh; .github/workflows/install_hdf5.sh 1.8.11; 
           # Run units tests but disable test_h5plugin.py
           CIBW_TEST_COMMAND: CI_BUILD_WHEEL=1 pytest {package}/tests
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        hdf5: [1.10.2] #1.10.7]
+        hdf5: [1.10.1] #1.10.7]
 
     steps:
       # Checkout bitshuffle

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        hdf5: [1.8.15] #1.10.7]
+        hdf5: [1.8.20] #1.10.7]
 
     steps:
       # Checkout bitshuffle

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,37 @@
+name: Build bitshuffle wheels
+
+on: [pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+      # Checkout bitshuffle
+      - uses: actions/checkout@v2
+
+      # Used to host cibuildwheel
+      - uses: actions/setup-python@v2
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.0.0a3
+
+      # Build wheels for linux and x86 platforms
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_ARCHS_LINUX: "x86_64"
+          CIBW_BEFORE_ALL_LINUX: chmod +x .github/workflows/install_hdf5.sh; .github/workflows/install_hdf5.sh
+          CIBW_ENVIRONMENT: "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib"
+          CIBW_TEST_REQUIRES: pytest
+          # Run units tests but disable test_h5plugin.py
+          CIBW_TEST_COMMAND: CI_BUILD_WHEEL=1 pytest {package}/tests
+
+      # Package wheels and host on CI
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,4 +1,4 @@
-name: Build bitshuffle wheels
+name: Build bitshuffle wheels and upload to PyPI
 
 on: [pull_request]
 
@@ -29,6 +29,8 @@ jobs:
           CIBW_BEFORE_BUILD_LINUX: chmod +x .github/workflows/install_hdf5.sh; .github/workflows/install_hdf5.sh ${{ matrix.hdf5 }}
           CIBW_ENVIRONMENT: "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib"
           CIBW_TEST_REQUIRES: pytest
+          # Install different version of HDF5 for unit tests to ensure the 
+          # wheels are indepedent of HDF5 installation
           CIBW_BEFORE_TEST: chmod +x .github/workflows/install_hdf5.sh; .github/workflows/install_hdf5.sh 1.8.11; 
           # Run units tests but disable test_h5plugin.py
           CIBW_TEST_COMMAND: CI_BUILD_WHEEL=1 pytest {package}/tests
@@ -37,3 +39,41 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse-hdf5-${{ matrix.hdf5 }}/*.whl
+  
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.8'
+
+      - name: Build sdist
+        run: python setup.py sdist
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.tar.gz
+
+  # Upload to PyPI
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    # Upload to PyPI on every tag starting with 'v'
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    # Alternatively, to publish when a GitHub Release is created, use the following rule:
+    # if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}
+          # To test: repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -42,14 +42,26 @@ jobs:
   
   build_sdist:
     name: Build source distribution
+    strategy:
+      matrix:
+        python-version: [3.8]
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-python@v2
-        name: Install Python
+      - name: Install apt dependencies
+        run: |
+          sudo apt-get install -y libhdf5-serial-dev hdf5-tools pkg-config
+
+      - name: Install Python
+        uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install pip dependencies
+        run: |
+          pip install -r requirements.txt
 
       - name: Build sdist
         run: python setup.py sdist

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        hdf5: [1.10.7]
+        hdf5: [1.8.15] #1.10.7]
 
     steps:
       # Checkout bitshuffle
@@ -29,7 +29,7 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: chmod +x .github/workflows/install_hdf5.sh; .github/workflows/install_hdf5.sh ${{ matrix.hdf5 }}
           CIBW_ENVIRONMENT: "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib"
           CIBW_TEST_REQUIRES: pytest
-          CIBW_BEFORE_TEST: chmod +x .github/workflows/install_hdf5.sh; .github/workflows/install_hdf5.sh 1.8.15; 
+          CIBW_BEFORE_TEST: chmod +x .github/workflows/install_hdf5.sh; .github/workflows/install_hdf5.sh ${{ matrix.hdf5 }}; 
           # Run units tests but disable test_h5plugin.py
           CIBW_TEST_COMMAND: CI_BUILD_WHEEL=1 pytest {package}/tests
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        hdf5: [1.8.20] #1.10.7]
+        hdf5: [1.10.2] #1.10.7]
 
     steps:
       # Checkout bitshuffle

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        hdf5: [1.10.1] #1.10.7]
+        hdf5: [1.10.7]
 
     steps:
       # Checkout bitshuffle
@@ -26,10 +26,10 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse-hdf5-${{ matrix.hdf5 }}
         env:
           CIBW_ARCHS_LINUX: "x86_64"
-          CIBW_BEFORE_ALL_LINUX: chmod +x .github/workflows/install_hdf5.sh; .github/workflows/install_hdf5.sh ${{ matrix.hdf5 }}
+          CIBW_BEFORE_BUILD_LINUX: chmod +x .github/workflows/install_hdf5.sh; .github/workflows/install_hdf5.sh ${{ matrix.hdf5 }}
           CIBW_ENVIRONMENT: "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib"
           CIBW_TEST_REQUIRES: pytest
-          CIBW_BEFORE_TEST: chmod +x .github/workflows/install_hdf5.sh; .github/workflows/install_hdf5.sh ${{ matrix.hdf5 }}; 
+          CIBW_BEFORE_TEST: chmod +x .github/workflows/install_hdf5.sh; .github/workflows/install_hdf5.sh 1.8.11; 
           # Run units tests but disable test_h5plugin.py
           CIBW_TEST_COMMAND: CI_BUILD_WHEEL=1 pytest {package}/tests
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -29,7 +29,7 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: chmod +x .github/workflows/install_hdf5.sh; .github/workflows/install_hdf5.sh ${{ matrix.hdf5 }}
           CIBW_ENVIRONMENT: "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib"
           CIBW_TEST_REQUIRES: pytest
-          CIBW_BEFORE_TEST: chmod +x .github/workflows/install_hdf5.sh; .github/workflows/install_hdf5.sh 1.8.11; 
+          CIBW_BEFORE_TEST: chmod +x .github/workflows/install_hdf5.sh; .github/workflows/install_hdf5.sh 1.8.15; 
           # Run units tests but disable test_h5plugin.py
           CIBW_TEST_COMMAND: CI_BUILD_WHEEL=1 pytest {package}/tests
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -74,8 +74,8 @@ jobs:
   upload_pypi:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
-    # Upload to PyPI on every tag starting with 'v'
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    # Upload to PyPI on every tag
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     # Alternatively, to publish when a GitHub Release is created, use the following rule:
     # if: github.event_name == 'release' && github.event.action == 'published'
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+# Include dependencies when building wheels on cibuildwheel
+[build-system]
+requires = [
+    "setuptools>=0.7",
+    "Cython>=0.19",
+    "numpy>=1.6.1",
+    "h5py>=2.4.0",
+]
+
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "setuptools>=0.7",
     "Cython>=0.19",
     "numpy>=1.6.1",
-    "h5py>=2.4.0",
+    "h5py==3.1.0",
 ]
 
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "setuptools>=0.7",
     "Cython>=0.19",
     "numpy>=1.6.1",
-    "h5py==3.1.0",
+    "h5py>=2.4.0",
 ]
 
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@
 setuptools>=0.7
 Cython>=0.19
 numpy>=1.6.1
-h5py==3.1.0
+h5py>=2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@
 setuptools>=0.7
 Cython>=0.19
 numpy>=1.6.1
-h5py>=2.4.0
+h5py==3.1.0

--- a/src/hdf5_dl.c
+++ b/src/hdf5_dl.c
@@ -31,8 +31,8 @@
  */
 #include <stdarg.h>
 #include <dlfcn.h>
+#include <stdbool.h>
 #include "hdf5.h"
-#include "H5PLextern.h"
 
 
 /*Function types*/

--- a/tests/test_h5plugin.py
+++ b/tests/test_h5plugin.py
@@ -5,6 +5,7 @@ import glob
 
 import numpy as np
 import h5py
+import pytest
 from subprocess import Popen, PIPE, STDOUT
 
 import bitshuffle
@@ -25,6 +26,10 @@ else:
 
 
 class TestFilterPlugins(unittest.TestCase):
+    @pytest.mark.skipif(
+        "CI_BUILD_WHEEL" in os.environ,
+        reason="Can't build dynamic HDF5 plugin into bitshuffle wheel.",
+    )
     def test_plugins(self):
         if not H51811P:
             return


### PR DESCRIPTION
These changes automate building bitshuffle wheels for Linux x86. 

How do you want the wheels uploaded to PyPI, @kiyo-masui? There are various options (https://cibuildwheel.readthedocs.io/en/stable/deliver-to-pypi/ - you can even automate it and only upload on tagged versions of bitshuffle.