### PR TITLE
Use nogil for shuffle/unshuffle and compress/decompress

### DIFF
--- a/bitshuffle/ext.pyx
+++ b/bitshuffle/ext.pyx
@@ -25,14 +25,14 @@ cdef extern from b"bitshuffle.h":
     int bshuf_using_SSE2()
     int bshuf_using_AVX2()
     int bshuf_bitshuffle(void *A, void *B, int size, int elem_size,
-                         int block_size)
+                         int block_size) nogil
     int bshuf_bitunshuffle(void *A, void *B, int size, int elem_size,
-                           int block_size)
+                           int block_size) nogil
     int bshuf_compress_lz4_bound(int size, int elem_size, int block_size)
     int bshuf_compress_lz4(void *A, void *B, int size, int elem_size,
-                           int block_size)
+                           int block_size) nogil
     int bshuf_decompress_lz4(void *A, void *B, int size, int elem_size,
-                             int block_size)
+                             int block_size) nogil
     int BSHUF_VERSION_MAJOR
     int BSHUF_VERSION_MINOR
     int BSHUF_VERSION_POINT
@@ -290,8 +290,9 @@ def bitshuffle(np.ndarray arr not None, int block_size=0):
     cdef void* arr_ptr = <void*> &arr_flat[0]
     cdef void* out_ptr = <void*> &out_flat[0]
 
-    for ii in range(REPEATC):
-        count = bshuf_bitshuffle(arr_ptr, out_ptr, size, itemsize, block_size)
+    with nogil:
+        for ii in range(REPEATC):
+            count = bshuf_bitshuffle(arr_ptr, out_ptr, size, itemsize, block_size)
     if count < 0:
         msg = "Failed. Error code %d."
         excp = RuntimeError(msg % count, count)
@@ -333,8 +334,9 @@ def bitunshuffle(np.ndarray arr not None, int block_size=0):
     cdef void* arr_ptr = <void*> &arr_flat[0]
     cdef void* out_ptr = <void*> &out_flat[0]
 
-    for ii in range(REPEATC):
-        count = bshuf_bitunshuffle(arr_ptr, out_ptr, size, itemsize, block_size)
+    with nogil:
+        for ii in range(REPEATC):
+            count = bshuf_bitunshuffle(arr_ptr, out_ptr, size, itemsize, block_size)
     if count < 0:
         msg = "Failed. Error code %d."
         excp = RuntimeError(msg % count, count)
@@ -382,8 +384,9 @@ def compress_lz4(np.ndarray arr not None, int block_size=0):
     out_flat = out.view(np.uint8).ravel()
     cdef void* arr_ptr = <void*> &arr_flat[0]
     cdef void* out_ptr = <void*> &out_flat[0]
-    for ii in range(REPEATC):
-        count = bshuf_compress_lz4(arr_ptr, out_ptr, size, itemsize, block_size)
+    with nogil:
+        for ii in range(REPEATC):
+            count = bshuf_compress_lz4(arr_ptr, out_ptr, size, itemsize, block_size)
     if count < 0:
         msg = "Failed. Error code %d."
         excp = RuntimeError(msg % count, count)
@@ -433,9 +436,10 @@ def decompress_lz4(np.ndarray arr not None, shape, dtype, int block_size=0):
     out_flat = out.view(np.uint8).ravel()
     cdef void* arr_ptr = <void*> &arr_flat[0]
     cdef void* out_ptr = <void*> &out_flat[0]
-    for ii in range(REPEATC):
-        count = bshuf_decompress_lz4(arr_ptr, out_ptr, size, itemsize,
-                                     block_size)
+    with nogil:
+        for ii in range(REPEATC):
+            count = bshuf_decompress_lz4(arr_ptr, out_ptr, size, itemsize,
+                                         block_size)
     if count < 0:
         msg = "Failed. Error code %d."
         excp = RuntimeError(msg % count, count)


### PR DESCRIPTION
This PR makes the 4 functions bitshuffle, bitunshuffle, compress_lz4, decompress_lz4 releasing Python's GIL while calling the underlying C function.

This would be usefull for multi-threaded usage.

Closes #100