### PR TITLE
Bshuf_decompress_zstd_block consistent with bshuf_decompress_lz4_block 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,4 +55,4 @@ jobs:
         python setup.py install --h5plugin --h5plugin-dir ~/hdf5/lib --zstd
 
     - name: Run tests
-      run: pytest .
+      run: pytest -v .

--- a/src/bitshuffle.c
+++ b/src/bitshuffle.c
@@ -188,6 +188,8 @@ int64_t bshuf_decompress_zstd_block(ioc_chain *C_ptr,
         free(tmp_buf);
         return -91;
     }
+
+    nbytes = nbytes_from_header;
     count = bshuf_untrans_bit_elem(tmp_buf, out, size, elem_size);
     CHECK_ERR_FREE(count, tmp_buf);
     nbytes += 4;

--- a/src/bitshuffle.h
+++ b/src/bitshuffle.h
@@ -98,11 +98,6 @@ int64_t bshuf_compress_lz4(const void* in, void* out, const size_t size, const s
  * To properly unshuffle bitshuffled data, *size*, *elem_size* and *block_size*
  * must patch the parameters used to compress the data.
  *
- * NOT TO BE USED WITH UNTRUSTED DATA: This routine uses the function
- * LZ4_decompress_fast from LZ4, which does not protect against maliciously
- * formed datasets. By modifying the compressed data, this function could be
- * coerced into leaving the boundaries of the input buffer.
- *
  * Parameters
  * ----------
  *  in : input buffer
@@ -183,11 +178,6 @@ int64_t bshuf_compress_zstd(const void* in, void* out, const size_t size, const 
  *
  * To properly unshuffle bitshuffled data, *size*, *elem_size* and *block_size*
  * must patch the parameters used to compress the data.
- *
- * NOT TO BE USED WITH UNTRUSTED DATA: This routine uses the function
- * ZSTD_decompress_fast from ZSTD, which does not protect against maliciously
- * formed datasets. By modifying the compressed data, this function could be
- * coerced into leaving the boundaries of the input buffer.
  *
  * Parameters
  * ----------


### PR DESCRIPTION
There is currently wrong return value of bshuf_decompress_zstd_block leading to issues with decompression, simple compress/decompress test is giving wrong result. 

Signed-off-by: Filip Leonarski <filip.leonarski@psi.ch>