### PR TITLE
Build backend updated to poetry core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,23 @@
-# Include dependencies when building wheels on cibuildwheel
+[tool.poetry]
+name = "bitshuffle"
+version = "0.4.2"
+description = "Filter for improving compression of typed binary data."
+authors = ["Kiyoshi Masui"]
+license = "MIT"
+
+[tool.poetry.dependencies]
+python = ">=2.7, >=3.3"
+setuptools = ">=0.7"
+Cython = ">=0.19"
+numpy = ">=1.6.1"
+h5py = ">=2.4.0"
+
 [build-system]
 requires = [
+    "poetry-core>=1.0.0",
     "setuptools>=0.7",
     "Cython>=0.19",
     "oldest-supported-numpy",
     "h5py>=2.4.0",
 ]
-
-build-backend = "setuptools.build_meta"
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This solves issue #118 and makes the repository compatible with poetry. To do so, it updates the style of `pyproject.toml` and uses its [light weight, fully compliant, self-contained package allowing PEP 517 compatible build frontends](https://github.com/python-poetry/poetry-core#poetry-core), solving the error indicated in the issue