### PR TITLE
Fix build error C2036 on Windows

### DIFF
--- a/src/bitshuffle.c
+++ b/src/bitshuffle.c
@@ -182,7 +182,7 @@ int64_t bshuf_decompress_zstd_block(ioc_chain *C_ptr,
     tmp_buf = malloc(size * elem_size);
     if (tmp_buf == NULL) return -1;
 
-    nbytes = ZSTD_decompress(tmp_buf, size * elem_size, in + 4, nbytes_from_header);
+    nbytes = ZSTD_decompress(tmp_buf, size * elem_size, (void *)((char *) in + 4), nbytes_from_header);
     CHECK_ERR_FREE_LZ(nbytes, tmp_buf);
     if (nbytes != size * elem_size) {
         free(tmp_buf);


### PR DESCRIPTION
I get the following error when build on Windows with Microsoft Visual Studio 14.0:
`bitshuffle.c(185): error C2036: 'const void *': unknown size`
This PR fixes it.