### PR TITLE
Add the CPATH to cibw

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -34,6 +34,7 @@ jobs:
           # Only build Haswell wheels on x86 for compatibility
           CIBW_ENVIRONMENT: >
             LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+            CPATH=/usr/local/include
             ENABLE_ZSTD=1
             BITSHUFFLE_ARCH=haswell
           CIBW_TEST_REQUIRES: pytest

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           output-dir: ./wheelhouse-hdf5-${{ matrix.hdf5}}
         env:
-          CIBW_SKIP: "pp* *musllinux*"
+          CIBW_SKIP: "pp* *musllinux* cp311-macosx*"
           CIBW_ARCHS: "x86_64"
           CIBW_BEFORE_ALL: |
             chmod +x .github/workflows/install_hdf5.sh

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ import platform
 
 
 VERSION_MAJOR = 0
-VERSION_MINOR = 4
-VERSION_POINT = 2
+VERSION_MINOR = 5
+VERSION_POINT = 1
 # Define ZSTD macro for cython compilation
 default_options["compile_time_env"] = {"ZSTD_SUPPORT": False}
 

--- a/setup.py
+++ b/setup.py
@@ -222,7 +222,18 @@ for p in ["/usr/include"] + pkgconfig("hdf5")["include_dirs"] + CPATHS:
 if HDF5_FILTER_SUPPORT:
     EXTENSIONS.append(h5filter)
 
+# Check for plugin hdf5 plugin support (hdf5 >= 1.8.11)
+HDF5_PLUGIN_SUPPORT = False
+CPATHS = os.environ["CPATH"].split(":") if "CPATH" in os.environ else []
+for p in ["/usr/include"] + pkgconfig("hdf5")["include_dirs"] + CPATHS:
+    if os.path.exists(os.path.join(p, "H5PLextern.h")):
+        HDF5_PLUGIN_SUPPORT = True
+
+if HDF5_PLUGIN_SUPPORT:
+    EXTENSIONS.extend([filter_plugin, lzf_plugin])
+
 # For enabling ZSTD support when building wheels
+# This needs to be done after all Extensions have been added to EXTENSIONS
 if "ENABLE_ZSTD" in os.environ:
     default_options["compile_time_env"] = {"ZSTD_SUPPORT": True}
     for ext in EXTENSIONS:
@@ -235,16 +246,6 @@ if "ENABLE_ZSTD" in os.environ:
             ext.include_dirs += zstd_lib
             ext.depends += zstd_headers
             ext.define_macros += [("ZSTD_SUPPORT", 1)]
-
-# Check for plugin hdf5 plugin support (hdf5 >= 1.8.11)
-HDF5_PLUGIN_SUPPORT = False
-CPATHS = os.environ["CPATH"].split(":") if "CPATH" in os.environ else []
-for p in ["/usr/include"] + pkgconfig("hdf5")["include_dirs"] + CPATHS:
-    if os.path.exists(os.path.join(p, "H5PLextern.h")):
-        HDF5_PLUGIN_SUPPORT = True
-
-if HDF5_PLUGIN_SUPPORT:
-    EXTENSIONS.extend([filter_plugin, lzf_plugin])
 
 
 class develop(develop_):


### PR DESCRIPTION
There was an unexpected issue in the wheel builds as they were missing bitshuffle.h5. I think this comes from the merging of  #120 and it not finding the headers it needs in the correct place.