### PR TITLE
Support numpy 2.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,11 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.10"]
+        python-version: ["3.7", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, macos-latest]
         exclude:
         - os: macos-latest
-          python-version: "3.6"
+          python-version: "3.7"
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 requires = [
     "setuptools>=0.7",
     "Cython>=0.19",
-    "oldest-supported-numpy",
+    "numpy>=1.6.1",
     "h5py>=2.4.0",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ import platform
 
 VERSION_MAJOR = 0
 VERSION_MINOR = 5
-VERSION_POINT = 1
+VERSION_POINT = 2
 # Define ZSTD macro for cython compilation
 default_options["compile_time_env"] = {"ZSTD_SUPPORT": False}
 

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -25,7 +25,7 @@ TEST_DTYPES = [
     np.float64,
     np.complex128,
 ]
-TEST_DTYPES += [b"a3", b"a5", b"a6", b"a7", b"a9", b"a11", b"a12", b"a24", b"a48"]
+TEST_DTYPES += [b"S3", b"S5", b"S6", b"S7", b"S9", b"S11", b"S12", b"S24", b"S48"]
 
 
 class TestProfile(unittest.TestCase):


### PR DESCRIPTION
- Allow numpy 2.0.0 to satisfy dependency requirement
- Replace dtype declaration with np 2.0 compliant version
- Update workflow to avoid using testing resources that are no longer provided
- Bump minor version