### PR TITLE
Fix `lzf_filter` compatibility with HDF5 > 1.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,15 +12,12 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.10"]
+        python-version: ["3.9", "3.10", "3.12"]
         os: [ubuntu-latest, macos-latest]
-        exclude:
-        - os: macos-latest
-          python-version: "3.6"
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install apt dependencies
       if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -35,7 +32,7 @@ jobs:
         brew install hdf5 pkg-config
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,11 +25,13 @@ jobs:
     - name: Install apt dependencies
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
+        sudo apt-get update
         sudo apt-get install -y libhdf5-serial-dev hdf5-tools pkg-config
 
     - name: Install homebrew dependencies
       if: ${{ matrix.os == 'macos-latest' }}
       run: |
+        brew update
         brew install hdf5 pkg-config
 
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -13,15 +13,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        hdf5: ["1.10.7"]
+        hdf5: ["1.10.7", "1.14.4"]
 
     steps:
       # Checkout bitshuffle
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Build wheels for linux and x86 platforms
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.2
+        uses: pypa/cibuildwheel@v2.19.2
         with:
           output-dir: ./wheelhouse-hdf5-${{ matrix.hdf5}}
         env:
@@ -57,18 +57,18 @@ jobs:
     name: Build source distribution
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.9"]
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install apt dependencies
         run: |
           sudo apt-get install -y libhdf5-serial-dev hdf5-tools pkg-config
 
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/lzf/lzf_filter.c
+++ b/lzf/lzf_filter.c
@@ -43,18 +43,22 @@
 #endif
 
 /*  Deal with the mutiple definitions for H5Z_class_t.
-    Note: Only HDF5 1.6 and 1.8 are supported.
+    Note: HDF5 1.6 and >= 1.8 are supported.
+    See https://portal.hdfgroup.org/hdf5/develop/group___h5_z.html#title6
+    for version history.
 
     (1) The old class should always be used for HDF5 1.6
     (2) The new class should always be used for HDF5 1.8 < 1.8.3
-    (3) The old class should be used for HDF5 1.8 >= 1.8.3 only if the
+    (3) The old class should be used for HDF5 >= 1.8.3 only if the
         macro H5_USE_16_API is set
 */
 
-#if H5_VERS_MAJOR == 1 && H5_VERS_MINOR == 8 && (H5_VERS_RELEASE < 3 || !H5_USE_16_API)
-#define H5PY_H5Z_NEWCLS 1
+#if H5_VERS_MAJOR == 1 && H5_VERS_MINOR < 8
+#define H5PY_H5Z_NEWCLS 0
+#elif H5_VERS_MAJOR == 1 && H5_VERS_MINOR >= 8 && H5_VERS_RELEASE >= 3 && H5_USE_16_API
+#define H5PY_H5Z_NEWCLS 0
 #else
-#define H5PY_H5Z_NEWCLS 0   
+#define H5PY_H5Z_NEWCLS 1
 #endif
 
 size_t lzf_filter(unsigned flags, size_t cd_nelmts,


### PR DESCRIPTION
Fixes a long-standing issue which only became obvious with recent compiler updates (see kiyo-masui/bitshuffle#153). 

 Changes to the structure of `H5Z_class_t` were made in HDF5 versions 1.6, 1.8, and 1.8.3. The logic for selecting which class version to use in `lzf_filter.c` assumed the old class by default and _only_ used the new class for HDF5 version 1.8.x. Based on kiyo-masui/bitshuffle#153, it seems that some compilers recently started treating warnings generated by this old class structure as errors, causing bitshuffle to fail to build.

This PR also updates python versions used in CI main (python 3.8 will reach end of life [soon](https://devguide.python.org/versions/)) and tests wheels for the most recent version of HDF5.

### Fixes
kiyo-masui/bitshuffle#153