### PR TITLE
Fixed Python 3.13 rc build image

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -58,7 +58,7 @@ jobs:
     name: Build source distribution
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13-rc.2"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13.0-rc.2"]
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -58,7 +58,7 @@ jobs:
     name: Build source distribution
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13-rc"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13-rc.2"]
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -58,7 +58,7 @@ jobs:
     name: Build source distribution
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13-rc"]
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Not sure why, but in order to build for Python 3.13 I had to specify the exact version and release candidate.