### PR TITLE
Fix build error on MSVC

### DIFF
--- a/src/bitshuffle_core.c
+++ b/src/bitshuffle_core.c
@@ -49,7 +49,11 @@ typedef int64_t omp_size_t;
 typedef size_t omp_size_t;
 #endif
 
-typedef uint16_t alias_uint16_t __attribute__((may_alias));
+#if defined(_MSC_VER)
+  typedef uint16_t alias_uint16_t;
+#else
+  typedef uint16_t alias_uint16_t __attribute__((may_alias));
+#endif
 
 // Macros.
 #define CHECK_MULT_EIGHT(n) do { if ((n) % 8) return -80; } while (0)


### PR DESCRIPTION
Fixes the following syntax errors when building with Microsoft Visual C compiler:
```
src/bitshuffle_core.c(52): error C2061: syntax error: identifier '__attribute__'
src/bitshuffle_core.c(52): error C2059: syntax error: ';'
```

Re #161.